### PR TITLE
feature: customize SDK to take `clientId` and `clientSecret` and handle token refresh 

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -2,3 +2,6 @@
 
 README.md
 sample-app/src/main/java/sample/App.java
+
+src/main/java/com/suger/api/SugerApiClientBuilder
+src/main/java/com/suger/api/utils

--- a/sample-app/src/main/java/sample/App.java
+++ b/sample-app/src/main/java/sample/App.java
@@ -8,7 +8,8 @@ public final class App {
 
     public static void main(String[] args) {
         SugerApiClient suger = SugerApiClient.builder()
-                .apiKey(System.getenv("SUGER_API_KEY"))
+                .clientId(System.getenv("SUGER_CLIENT_ID"))
+                .clientSecret(System.getenv("SUGER_CLIENT_SECRET"))
                 .build();
 
         SharedWorkloadEntitlement entitlement =

--- a/src/main/java/com/suger/api/SugerApiClientBuilder.java
+++ b/src/main/java/com/suger/api/SugerApiClientBuilder.java
@@ -2,6 +2,7 @@ package com.suger.api;
 
 import com.suger.api.core.ClientOptions;
 import com.suger.api.core.Environment;
+import com.suger.api.utils.TokenSupplier;
 import java.lang.String;
 
 public final class SugerApiClientBuilder {
@@ -9,8 +10,17 @@ public final class SugerApiClientBuilder {
 
   private Environment environment = Environment.DEFAULT;
 
-  public SugerApiClientBuilder apiKey(String apiKey) {
-    this.clientOptionsBuilder.addHeader("Authorization", apiKey);
+  private String clientId = null;
+
+  private String clientSecret = null;
+
+  public SugerApiClientBuilder clientId(String clientId) {
+    this.clientId = clientId;
+    return this;
+  }
+
+  public SugerApiClientBuilder clientSecret(String clientSecret) {
+    this.clientSecret = clientSecret;
     return this;
   }
 
@@ -26,6 +36,7 @@ public final class SugerApiClientBuilder {
 
   public SugerApiClient build() {
     clientOptionsBuilder.environment(this.environment);
+    clientOptionsBuilder.addHeader("Authorization", new TokenSupplier(clientId, clientSecret));
     return new SugerApiClientImpl(clientOptionsBuilder.build());
   }
 }

--- a/src/main/java/com/suger/api/utils/TokenSupplier.java
+++ b/src/main/java/com/suger/api/utils/TokenSupplier.java
@@ -1,0 +1,25 @@
+package com.suger.api.utils;
+
+import java.util.function.Supplier;
+
+public final class TokenSupplier implements Supplier<String> {
+
+    private String token = null;
+
+    private final String clientId;
+
+    private final String clientSecret;
+
+    public TokenSupplier(String clientId, String clientSecret) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+    }
+
+    @Override
+    public String get() {
+        if (token == null) { // or if token is expired
+          // fetch token using client id and client secret
+        }
+        return token;
+    }
+}


### PR DESCRIPTION
This PR shows a proof-of-concept of how you can customize the SDK to accept `clientId` and `clientSecret` and add a token refreshing utility on top of the fern generated code. 

Steps: 
1. Modify the `SugerApiClientBuilder` class to take and store `clientId` and `clientSecret`. This class is now `.fernignored` meaning the generator will not touch it. 
2. Add a new class `com.suger.api.utils.TokenSupplier` which supplies the token. The TokenSupplier should be smart enough to initialize the token using clientId and clientSecret. You can add additional functionality here to check if a token is expired and if so to refresh it. 
